### PR TITLE
Dials endpoint

### DIFF
--- a/lib/alephant/broker/request.rb
+++ b/lib/alephant/broker/request.rb
@@ -8,6 +8,7 @@ module Alephant
 
       class NotFound; end
       class Status; end
+      class Dials; end
     end
   end
 end

--- a/lib/alephant/broker/request/factory.rb
+++ b/lib/alephant/broker/request/factory.rb
@@ -9,7 +9,7 @@ module Alephant
         extend Logger
 
         def self.request_type_from(env)
-          env.path.split("/")[1]
+          env.path.split('/')[1]
         end
 
         def self.request_for(load_strategy, env)
@@ -18,13 +18,16 @@ module Alephant
           logger.increment('request_count')
 
           case request_type_from(env)
-          when "component"
+          when 'component'
             logger.increment('actionable_request_count')
             Asset.new(component_factory, env)
-          when "components"
+          when 'components'
             logger.increment('actionable_request_count')
             Batch.new(component_factory, env)
-          when "status"
+          when 'dials'
+            logger.increment('dials_request')
+            Dials.new
+          when 'status'
             logger.increment('status_request')
             Status.new
           else

--- a/lib/alephant/broker/response.rb
+++ b/lib/alephant/broker/response.rb
@@ -1,9 +1,12 @@
+require "alephant/logger"
+
 module Alephant
   module Broker
     module Response
       require "alephant/broker/response/base"
       require "alephant/broker/response/asset"
       require "alephant/broker/response/batch"
+      require "alephant/broker/response/dials"
       require "alephant/broker/response/factory"
 
       class NotFound < Base

--- a/lib/alephant/broker/response/dials.rb
+++ b/lib/alephant/broker/response/dials.rb
@@ -1,0 +1,39 @@
+require 'alephant/logger'
+
+module Alephant
+  module Broker
+    module Response
+      class Dials < Base
+        include Logger
+
+        def initialize
+          super(status, 'application/json')
+        end
+
+        def setup
+          @content = File.read(dials_file)
+          log
+        end
+
+        def dials_file
+          '/etc/cosmos-dials/dials.json'
+        end
+
+        def dials_file_exists?
+          File.exist?(dials_file)
+        end
+
+        def status
+          dials_file_exists? ?
+            200 :
+            404
+        end
+
+        def log
+          logger.metric "BrokerResponse#{status}"
+          logger.info "Broker: Dials loaded! (#{status})"
+        end
+      end
+    end
+  end
+end

--- a/lib/alephant/broker/response/factory.rb
+++ b/lib/alephant/broker/response/factory.rb
@@ -1,4 +1,4 @@
-require "alephant/broker/response"
+require 'alephant/broker/response'
 
 module Alephant
   module Broker
@@ -10,6 +10,8 @@ module Alephant
             Asset.new(request.component, request_env)
           when Request::Batch
             Batch.new(request.components, request.batch_id, request_env)
+          when Request::Dials
+            Dials.new
           when Request::Status
             Status.new
           else


### PR DESCRIPTION
PR adds an endpoint to return [Dials](https://confluence.dev.bbc.co.uk/display/platform/Developing+with+Dials) config in an Alephant Broker.

The basis of this work is to enable Dials config to be served over an Alephant Broker, and by extension `www`. [WSRESPONSIVE-5183](https://jira.dev.bbc.co.uk/browse/WSRESPONSIVE-5183) is the basis for it, as it will make use of `amp-access`, which needs to point at endpoints that are available under `www`.